### PR TITLE
fix missing access rule on sw power plant item

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1887,7 +1887,8 @@
                     },
                     {
                         "name": "Southwest Item",
-                        "item_count": 1
+                        "item_count": 1,
+                        "access_rules": ["$plant"]
                     },
                     {
                         "name": "Central Dead End Hidden",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -1876,7 +1876,7 @@
             {
                 "name": "Power Plant",
                 "access_rules": [
-                    "$celadon,$cancut,$cansurf",
+                    "$cerulean,$cancut,$cansurf",
                     "$lavender,$canflash,$cansurf"
                 ],
                 "sections": [


### PR DESCRIPTION
This PR fixes two issues:

1) The access logic for the Southwest Item in the Power Plant is missing and is considered in logic even without the Plant Key. This can be recreated by having the following items: Oak's Package, Tea, HM03 Surf, Soul Badge, HM05 Flash, Boulderbadge. Logic allows getting to Route 9 via Rock Tunnel but the tracker currently says that the southwest item of the power plan is available when it is not without the Plant Key.

2) The access rules for the Power Plant state that Celadon should be in logic in order to get to the power plant via Cut and Surf, this should be Cerulean instead of Celadon. This can be recreated by having the following items: Oak's Package, HM01 Cut, Cascade Badge, HM03 Surf, Soul Badge, Plant Key. Power Plant should be in logic but is not considered in logic until getting access to Celadon (eg. with Tea).