### PR TITLE
Added OOL for not having Flash

### DIFF
--- a/locations/locations.json
+++ b/locations/locations.json
@@ -501,7 +501,7 @@
                 "name": "Route 9",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavender,$canflash"
+                    "$lavender,[canflash]"
                 ],
                 "sections": [
                     {
@@ -532,7 +532,7 @@
                 "name": "Route 10 North",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavender,$canflash"
+                    "$lavender,[canflash]"
                 ],
                 "sections": [
                     {
@@ -558,7 +558,7 @@
             {
                 "name": "Route 10 South",
                 "access_rules": [
-                    "$cerulean,$cancut,$canflash",
+                    "$cerulean,$cancut,[canflash]",
                     "$lavender"
                 ],
                 "sections": [
@@ -585,7 +585,8 @@
             {
                 "name": "Lavender Town",
                 "access_rules": [
-                    "$lavender"
+                    "$lavender",
+					"$cerulean,$cancut,[canflash]"
                 ],
                 "sections": [
                     {
@@ -605,7 +606,8 @@
             {
                 "name": "Route 8",
                 "access_rules": [
-                    "$lavender"
+                    "$lavender",
+					"$cerulean,$cancut,[canflash]"
                 ],
                 "sections": [
                     {
@@ -625,7 +627,8 @@
             {
                 "name": "Pokemon Tower",
                 "access_rules": [
-                    "$lavender"
+                    "$lavender",
+					"$cerulean,$cancut,[canflash]"
                 ],
                 "sections": [
                     {
@@ -945,6 +948,7 @@
                         "access_rules": [
                             "$vermillion,$boulders,$aide11",
                             "$lavender,pokeflute,$aide11",
+							"$cerulean,$cancut,[canflash],pokeflute,$aide11",
                             "$fuchsia,pokeflute,$boulders,$aide11",
                             "$fuchsia,pokeflute,$cansurf,$aide11"
                         ]
@@ -956,10 +960,12 @@
                         "access_rules": [
                             "$vermillion,$boulders,itemfinder",
                             "$lavender,pokeflute,itemfinder",
+							"$cerulean,$cancut,[canflash],pokeflute,itemfinder",
                             "$fuchsia,pokeflute,$boulders,itemfinder",
                             "$fuchsia,pokeflute,surf,itemfinder",
                             "$vermillion,$boulders,op_if_off",
                             "$lavender,pokeflute,op_if_off",
+							"$cerulean,$cancut,[canflash],pokeflute,op_if_off",
                             "$fuchsia,pokeflute,$boulders,op_if_off",
                             "$fuchsia,pokeflute,surf,op_if_off"
                         ],
@@ -977,7 +983,8 @@
             {
                 "name": "Route 12 North",
                 "access_rules": [
-                    "$lavender"
+                    "$lavender",
+					"$cerulean,$cancut,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1007,7 +1014,9 @@
                 "name": "Route 12 South",
                 "access_rules": [
                     "$lavender,pokeflute",
-                    "$lavender,$cansurf"
+					"$cerulean,$cancut,[canflash],pokeflute",
+                    "$lavender,$cansurf",
+					"$cerulean,$cancut,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -1041,7 +1050,10 @@
             },
             {
                 "name": "Underground Tunnel West-East",
-                "access_rules": ["$lavender"],
+                "access_rules": [
+				    "$lavender",
+					"$cerulean,$cancut,[canflash]"
+				],
                 "sections": [
                     {
                         "name": "West Hidden",
@@ -1072,7 +1084,8 @@
             {
                 "name": "Celadon City",
                 "access_rules": [
-                    "$celadon"
+                    "$celadon",
+					"$cerulean,$cancut,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1137,12 +1150,19 @@
                         "name": "Trainers",
                         "item_count": 6,
                         "visibility_rules": ["op_trn_on"],
-                        "access_rules": ["$celadon,bike,pokeflute","$fuchsia,bike"]
+                        "access_rules": [
+							"$celadon,bike,pokeflute",
+							"$fuchsia,bike",
+							"$cerulean,$cancut,[canflash],$cansurf,bike"
+						]
                     },
                     {
                         "name": "House Woman",
                         "item_count": 1,
-                        "access_rules": ["$celadon,$cancut"]
+                        "access_rules": [
+							"$celadon,$cancut",
+							"$cerulean,$cancut,[canflash]"
+						]
                     }
                 ],
                 "map_locations": [
@@ -1157,7 +1177,8 @@
                 "name": "Route 17",
                 "access_rules": [
                     "$celadon,pokeflute,bike",
-                    "$fuchsia,bike"
+                    "$fuchsia,bike",
+					"$cerulean,$cancut,[canflash],$cansurf,bike"
                 ],
                 "sections": [
                     {
@@ -1207,7 +1228,8 @@
             {
                 "name": "Fuchsia City",
                 "access_rules": [
-                    "$fuchsia"
+                    "$fuchsia",
+					"$cerulean,$cancut,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -1244,7 +1266,10 @@
             },
             {
                 "name": "Safari Zone",
-                "access_rules": ["$fuchsia,$safari"],
+                "access_rules": [
+					"$fuchsia,$safari",
+					"$cerulean,$cancut,[canflash],$cansurf,$safari"
+				],
                 "sections": [
                     {
                         "name": "Center Zone Island Item",
@@ -1313,7 +1338,8 @@
             {
                 "name": "Route 15",
                 "access_rules": [
-                    "$fuchsia"
+                    "$fuchsia",
+					"$cerulean,$cancut,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -1348,7 +1374,10 @@
             },
             {
                 "name": "Route 14",
-                "access_rules": ["$fuchsia"],
+                "access_rules": [
+					"$fuchsia",
+					"$cerulean,$cancut,[canflash],$cansurf"
+				],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -1367,31 +1396,54 @@
             {
                 "name": "Route 13",
                 "access_rules": [
-                    "$fuchsia"
+                    "$fuchsia",
+					"$cerulean,$cancut,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
                         "name": "Dead End Bush Hidden",
                         "item_count": 1,
-                        "access_rules": ["$fuchsia,itemfinder","$fuchsia,op_if_off"],
+                        "access_rules": [
+							"$fuchsia,itemfinder",
+							"$cerulean,$cancut,[canflash],$cansurf,itemfinder",
+							"$fuchsia,op_if_off",
+							"$cerulean,$cancut,[canflash],$cansurf,op_if_off"
+						],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Dead End By Water Corner Hidden",
                         "item_count": 1,
-                        "access_rules": ["$fuchsia,itemfinder","$fuchsia,op_if_off"],
+                        "access_rules": [
+							"$fuchsia,itemfinder",
+							"$cerulean,$cancut,[canflash],$cansurf,itemfinder",
+							"$fuchsia,op_if_off",
+							"$cerulean,$cancut,[canflash],$cansurf,op_if_off"
+						],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Trainers",
                         "item_count": 7,
-                        "access_rules": ["$fuchsia"],
+                        "access_rules": [
+							"$fuchsia",
+							"$cerulean,$cancut,[canflash],$cansurf"
+						],
                         "visibility_rules": ["op_trn_on"]
                     },
                     {
                         "name": "East Trainers",
                         "item_count": 3,
-                        "access_rules": ["$fuchsia,$boulders","$fuchsia,$cansurf","$lavender,$cansurf","$lavender,pokeflute"],
+                        "access_rules": [
+							"$fuchsia,$boulders",
+							"$cerulean,$cancut,[canflash],$boulders",
+							"$fuchsia,$cansurf",
+							"$cerulean,$cancut,[canflash],$cansurf",
+							"$lavender,$cansurf",
+							"$cerulean,$cancut,[canflash],$cansurf",
+							"$lavender,pokeflute",
+							"$cerulean,$cancut,[canflash],pokeflute"
+						],
                         "visibility_rules": ["op_trn_on"]
                     }
                 ],
@@ -1459,8 +1511,8 @@
             {
                 "name": "Rock Tunnel",
                 "access_rules": [
-                    "$cerulean,$cancut,$canflash",
-                    "$lavender,$canflash"
+                    "$cerulean,$cancut,[canflash]",
+                    "$lavender,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1661,7 +1713,10 @@
             },
             {
                 "name": "Rocket Hideout",
-                "access_rules": ["$celadon,$hideout"],
+                "access_rules": [
+					"$celadon,$hideout",
+					"$cerulean,$cancut,[canflash],$hideout"
+				],
                 "sections": [
                     {
                         "name": "B1F West Item",
@@ -1734,7 +1789,10 @@
             },
             {
                 "name": "Rocket Hideout Trainers",
-                "access_rules": ["$celadon,$hideout"],
+                "access_rules": [
+					"$celadon,$hideout",
+					"$cerulean,$cancut,[canflash],$hideout"
+				],
                 "sections": [
                     {
                         "name": "B1F Rockets",
@@ -1879,7 +1937,7 @@
                 "name": "Power Plant",
                 "access_rules": [
                     "$cerulean,$cancut,$cansurf",
-                    "$lavender,$canflash,$cansurf"
+                    "$lavender,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -2139,7 +2197,11 @@
             },
             {
                 "name": "Route 20 East",
-                "access_rules": ["$cansurf,$canstrength","$fuchsia,$cansurf"],
+                "access_rules": [
+					"$cansurf,$canstrength",
+					"$fuchsia,$cansurf",
+					"$cerulean,$cancut,[canflash],$cansurf"
+				],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2157,7 +2219,11 @@
             },
             {
                 "name": "Route 19",
-                "access_rules": ["$cansurf,$canstrength","$fuchsia,$cansurf"],
+                "access_rules": [
+				    "$cansurf,$canstrength",
+					"$fuchsia,$cansurf",
+					"$cerulean,$cancut,[canflash],$cansurf"
+				],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2175,7 +2241,10 @@
             },
             {
                 "name": "Route 18",
-                "access_rules": ["$fuchsia"],
+                "access_rules": [
+				    "$fuchsia",
+					"$cerulean,$cancut,[canflash],$cansurf"
+				],
                 "sections": [
                     {
                         "name": "Trainers",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -561,7 +561,7 @@
                 "name": "Route 10 South",
                 "access_rules": [
                     "$cerulean,$cancut,[canflash]",
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -588,7 +588,7 @@
             {
                 "name": "Lavender Town",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -609,7 +609,7 @@
             {
                 "name": "Route 8",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
 					"$lavender"
                 ],
                 "sections": [

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -501,7 +501,7 @@
                 "name": "Route 9",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavendernoflash,[canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -533,7 +533,7 @@
                 "name": "Route 10 North",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavendernoflash,[canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -560,8 +560,8 @@
             {
                 "name": "Route 10 South",
                 "access_rules": [
-                    "$cerulean,$cancut,[canflash]",
-                    "$lavendernoflash,[canflash]",
+                    "$cerulean,$cancut,[$canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -588,7 +588,7 @@
             {
                 "name": "Lavender Town",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -609,7 +609,7 @@
             {
                 "name": "Route 8",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -630,7 +630,7 @@
             {
                 "name": "Pokemon Tower",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -950,9 +950,9 @@
                         "item_count": 1,
                         "access_rules": [
                             "$vermillion,$boulders,$aide11",
-                            "$lavendernoflash,[canflash],pokeflute,$aide11",
-                            "$fuchsianoflash,[canflash],pokeflute,$boulders,$aide11",
-                            "$fuchsianoflash,[canflash],pokeflute,$cansurf,$aide11",
+                            "$lavendernoflash,[$canflash],pokeflute,$aide11",
+                            "$fuchsianoflash,[$canflash],pokeflute,$boulders,$aide11",
+                            "$fuchsianoflash,[$canflash],pokeflute,$cansurf,$aide11",
                             "$lavender,pokeflute,$aide11",
                             "$fuchsia,pokeflute,$boulders,$aide11",
                             "$fuchsia,pokeflute,$cansurf,$aide11"
@@ -964,16 +964,16 @@
                         "item_count": 1,
                         "access_rules": [
                             "$vermillion,$boulders,itemfinder",
-                            "$lavendernoflash,[canflash],pokeflute,itemfinder",
-                            "$fuchsianoflash,[canflash],pokeflute,$boulders,itemfinder",
-                            "$fuchsianoflash,[canflash],pokeflute,surf,itemfinder",
+                            "$lavendernoflash,[$canflash],pokeflute,itemfinder",
+                            "$fuchsianoflash,[$canflash],pokeflute,$boulders,itemfinder",
+                            "$fuchsianoflash,[$canflash],pokeflute,surf,itemfinder",
                             "$lavender,pokeflute,itemfinder",
                             "$fuchsia,pokeflute,$boulders,itemfinder",
                             "$fuchsia,pokeflute,surf,itemfinder",
                             "$vermillion,$boulders,op_if_off",
-                            "$lavendernoflash,[canflash],pokeflute,op_if_off",
-                            "$fuchsianoflash,[canflash],pokeflute,$boulders,op_if_off",
-                            "$fuchsianoflash,[canflash],pokeflute,surf,op_if_off",
+                            "$lavendernoflash,[$canflash],pokeflute,op_if_off",
+                            "$fuchsianoflash,[$canflash],pokeflute,$boulders,op_if_off",
+                            "$fuchsianoflash,[$canflash],pokeflute,surf,op_if_off",
                             "$lavender,pokeflute,op_if_off",
                             "$fuchsia,pokeflute,$boulders,op_if_off",
                             "$fuchsia,pokeflute,surf,op_if_off"
@@ -992,7 +992,7 @@
             {
                 "name": "Route 12 North",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]",
+                    "$lavendernoflash,[$canflash]",
 					"$lavender"
                 ],
                 "sections": [
@@ -1022,8 +1022,8 @@
             {
                 "name": "Route 12 South",
                 "access_rules": [
-                    "$lavendernoflash,[canflash],pokeflute",
-                    "$lavendernoflash,[canflash],$cansurf",
+                    "$lavendernoflash,[$canflash],pokeflute",
+                    "$lavendernoflash,[$canflash],$cansurf",
                     "$lavender,pokeflute",
                     "$lavender,$cansurf"
                 ],
@@ -1059,7 +1059,7 @@
             },
             {
                 "name": "Underground Tunnel West-East",
-                "access_rules": ["$lavendernoflash,[canflash]","$lavender"],
+                "access_rules": ["$lavendernoflash,[$canflash]","$lavender"],
                 "sections": [
                     {
                         "name": "West Hidden",
@@ -1090,7 +1090,7 @@
             {
                 "name": "Celadon City",
                 "access_rules": [
-                    "$celadonnoflash,[canflash]",
+                    "$celadonnoflash,[$canflash]",
 					"$celadon"
                 ],
                 "sections": [
@@ -1156,12 +1156,12 @@
                         "name": "Trainers",
                         "item_count": 6,
                         "visibility_rules": ["op_trn_on"],
-                        "access_rules": ["$celadonnoflash,[canflash],bike,pokeflute","$celadon,bike,pokeflute","$fuchsianoflash,[canflash],bike","$fuchsia,bike"]
+                        "access_rules": ["$celadonnoflash,[$canflash],bike,pokeflute","$celadon,bike,pokeflute","$fuchsianoflash,[$canflash],bike","$fuchsia,bike"]
                     },
                     {
                         "name": "House Woman",
                         "item_count": 1,
-                        "access_rules": ["$celadonnoflash,[canflash],$cancut","$celadon,$cancut"]
+                        "access_rules": ["$celadonnoflash,[$canflash],$cancut","$celadon,$cancut"]
                     }
                 ],
                 "map_locations": [
@@ -1175,8 +1175,8 @@
             {
                 "name": "Route 17",
                 "access_rules": [
-                    "$celadonnoflash,[canflash],pokeflute,bike",
-                    "$fuchsianoflash,[canflash],bike",
+                    "$celadonnoflash,[$canflash],pokeflute,bike",
+                    "$fuchsianoflash,[$canflash],bike",
                     "$celadon,pokeflute,bike",
                     "$fuchsia,bike"
                 ],
@@ -1228,7 +1228,7 @@
             {
                 "name": "Fuchsia City",
                 "access_rules": [
-                    "$fuchsianoflash,[canflash]",
+                    "$fuchsianoflash,[$canflash]",
 					"$fuchsia"
                 ],
                 "sections": [
@@ -1266,7 +1266,7 @@
             },
             {
                 "name": "Safari Zone",
-                "access_rules": ["$fuchsianoflash,[canflash],$safari","$fuchsia,$safari"],
+                "access_rules": ["$fuchsianoflash,[$canflash],$safari","$fuchsia,$safari"],
                 "sections": [
                     {
                         "name": "Center Zone Island Item",
@@ -1335,7 +1335,7 @@
             {
                 "name": "Route 15",
                 "access_rules": [
-                    "$fuchsianoflash,[canflash]",
+                    "$fuchsianoflash,[$canflash]",
 					"$fuchsia"
                 ],
                 "sections": [
@@ -1371,7 +1371,7 @@
             },
             {
                 "name": "Route 14",
-                "access_rules": ["$fuchsianoflash,[canflash]","$fuchsia"],
+                "access_rules": ["$fuchsianoflash,[$canflash]","$fuchsia"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -1390,32 +1390,32 @@
             {
                 "name": "Route 13",
                 "access_rules": [
-                    "$fuchsianoflash,[canflash]",
+                    "$fuchsianoflash,[$canflash]",
 					"$fuchsia"
                 ],
                 "sections": [
                     {
                         "name": "Dead End Bush Hidden",
                         "item_count": 1,
-                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsia,itemfinder","$fuchsianoflash,[canflash],op_if_off","$fuchsia,op_if_off"],
+                        "access_rules": ["$fuchsianoflash,[$canflash],itemfinder","$fuchsia,itemfinder","$fuchsianoflash,[$canflash],op_if_off","$fuchsia,op_if_off"],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Dead End By Water Corner Hidden",
                         "item_count": 1,
-                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsia,itemfinder","$fuchsianoflash,[canflash],op_if_off","$fuchsia,op_if_off"],
+                        "access_rules": ["$fuchsianoflash,[$canflash],itemfinder","$fuchsia,itemfinder","$fuchsianoflash,[$canflash],op_if_off","$fuchsia,op_if_off"],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Trainers",
                         "item_count": 7,
-                        "access_rules": ["$fuchsianoflash,[canflash]","$fichsia"],
+                        "access_rules": ["$fuchsianoflash,[$canflash]","$fichsia"],
                         "visibility_rules": ["op_trn_on"]
                     },
                     {
                         "name": "East Trainers",
                         "item_count": 3,
-                        "access_rules": ["$fuchsianoflash,[canflash],$boulders","$fuchsianoflash,[canflash],$cansurf","$lavendernoflash,[canflash],$cansurf","$lavendernoflash,[canflash],pokeflute",
+                        "access_rules": ["$fuchsianoflash,[$canflash],$boulders","$fuchsianoflash,[$canflash],$cansurf","$lavendernoflash,[$canflash],$cansurf","$lavendernoflash,[$canflash],pokeflute",
 						"$fuchsia,$boulders","$fuchsia,$cansurf","$lavender,$cansurf","$lavender,pokeflute"
 						],
                         "visibility_rules": ["op_trn_on"]
@@ -1485,8 +1485,8 @@
             {
                 "name": "Rock Tunnel",
                 "access_rules": [
-                    "$cerulean,$cancut,[canflash]",
-                    "$lavendernoflash,[canflash]"
+                    "$cerulean,$cancut,[$canflash]",
+                    "$lavendernoflash,[$canflash]"
                 ],
                 "sections": [
                     {
@@ -1687,7 +1687,7 @@
             },
             {
                 "name": "Rocket Hideout",
-                "access_rules": ["$celadonnoflash,[canflash],$hideout","$celadon,$hideout"],
+                "access_rules": ["$celadonnoflash,[$canflash],$hideout","$celadon,$hideout"],
                 "sections": [
                     {
                         "name": "B1F West Item",
@@ -1760,7 +1760,7 @@
             },
             {
                 "name": "Rocket Hideout Trainers",
-                "access_rules": ["$celadonnoflash,[canflash],$hideout","$celadon,$hideout"],
+                "access_rules": ["$celadonnoflash,[$canflash],$hideout","$celadon,$hideout"],
                 "sections": [
                     {
                         "name": "B1F Rockets",
@@ -1905,7 +1905,7 @@
                 "name": "Power Plant",
                 "access_rules": [
                     "$cerulean,$cancut,$cansurf",
-                    "$lavendernoflash,[canflash],$cansurf"
+                    "$lavendernoflash,[$canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -2165,7 +2165,7 @@
             },
             {
                 "name": "Route 20 East",
-                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf","$fuchsia,$cansurf"],
+                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[$canflash],$cansurf","$fuchsia,$cansurf"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2183,7 +2183,7 @@
             },
             {
                 "name": "Route 19",
-                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf","$fuchsia,$cansurf"],
+                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[$canflash],$cansurf","$fuchsia,$cansurf"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2201,7 +2201,7 @@
             },
             {
                 "name": "Route 18",
-                "access_rules": ["$fuchsianoflash,[canflash]","$fuchsia"],
+                "access_rules": ["$fuchsianoflash,[$canflash]","$fuchsia"],
                 "sections": [
                     {
                         "name": "Trainers",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -501,7 +501,7 @@
                 "name": "Route 9",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavender,[canflash]"
+                    "$lavendernoflash,[canflash],$canflash"
                 ],
                 "sections": [
                     {
@@ -532,7 +532,7 @@
                 "name": "Route 10 North",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavender,[canflash]"
+                    "$lavendernoflash,[canflash],$canflash"
                 ],
                 "sections": [
                     {
@@ -558,8 +558,8 @@
             {
                 "name": "Route 10 South",
                 "access_rules": [
-                    "$cerulean,$cancut,[canflash]",
-                    "$lavender"
+                    "$cerulean,$cancut,$canflash",
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -585,8 +585,7 @@
             {
                 "name": "Lavender Town",
                 "access_rules": [
-                    "$lavender",
-					"$cerulean,$cancut,[canflash]"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -606,8 +605,7 @@
             {
                 "name": "Route 8",
                 "access_rules": [
-                    "$lavender",
-					"$cerulean,$cancut,[canflash]"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -627,8 +625,7 @@
             {
                 "name": "Pokemon Tower",
                 "access_rules": [
-                    "$lavender",
-					"$cerulean,$cancut,[canflash]"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -947,10 +944,9 @@
                         "item_count": 1,
                         "access_rules": [
                             "$vermillion,$boulders,$aide11",
-                            "$lavender,pokeflute,$aide11",
-							"$cerulean,$cancut,[canflash],pokeflute,$aide11",
-                            "$fuchsia,pokeflute,$boulders,$aide11",
-                            "$fuchsia,pokeflute,$cansurf,$aide11"
+                            "$lavendernoflash,[canflash],pokeflute,$aide11",
+                            "$fuchsianoflash,[canflash],pokeflute,$boulders,$aide11",
+                            "$fuchsianoflash,[canflash],pokeflute,$cansurf,$aide11"
                         ]
                     },
                     
@@ -959,15 +955,13 @@
                         "item_count": 1,
                         "access_rules": [
                             "$vermillion,$boulders,itemfinder",
-                            "$lavender,pokeflute,itemfinder",
-							"$cerulean,$cancut,[canflash],pokeflute,itemfinder",
-                            "$fuchsia,pokeflute,$boulders,itemfinder",
-                            "$fuchsia,pokeflute,surf,itemfinder",
+                            "$lavendernoflash,[canflash],pokeflute,itemfinder",
+                            "$fuchsianoflash,[canflash],pokeflute,$boulders,itemfinder",
+                            "$fuchsianoflash,[canflash],pokeflute,surf,itemfinder",
                             "$vermillion,$boulders,op_if_off",
-                            "$lavender,pokeflute,op_if_off",
-							"$cerulean,$cancut,[canflash],pokeflute,op_if_off",
-                            "$fuchsia,pokeflute,$boulders,op_if_off",
-                            "$fuchsia,pokeflute,surf,op_if_off"
+                            "$lavendernoflash,[canflash],pokeflute,op_if_off",
+                            "$fuchsianoflash,[canflash],pokeflute,$boulders,op_if_off",
+                            "$fuchsianoflash,[canflash],pokeflute,surf,op_if_off"
                         ],
                         "visibility_rules": ["op_hid_on"]
                     }
@@ -983,8 +977,7 @@
             {
                 "name": "Route 12 North",
                 "access_rules": [
-                    "$lavender",
-					"$cerulean,$cancut,[canflash]"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1013,10 +1006,8 @@
             {
                 "name": "Route 12 South",
                 "access_rules": [
-                    "$lavender,pokeflute",
-					"$cerulean,$cancut,[canflash],pokeflute",
-                    "$lavender,$cansurf",
-					"$cerulean,$cancut,[canflash],$cansurf"
+                    "$lavendernoflash,[canflash],pokeflute",
+                    "$lavendernoflash,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -1050,10 +1041,7 @@
             },
             {
                 "name": "Underground Tunnel West-East",
-                "access_rules": [
-				    "$lavender",
-					"$cerulean,$cancut,[canflash]"
-				],
+                "access_rules": ["$lavendernoflash,[canflash]"],
                 "sections": [
                     {
                         "name": "West Hidden",
@@ -1084,8 +1072,7 @@
             {
                 "name": "Celadon City",
                 "access_rules": [
-                    "$celadon",
-					"$cerulean,$cancut,[canflash]"
+                    "$celadonnoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1150,19 +1137,12 @@
                         "name": "Trainers",
                         "item_count": 6,
                         "visibility_rules": ["op_trn_on"],
-                        "access_rules": [
-							"$celadon,bike,pokeflute",
-							"$fuchsia,bike",
-							"$cerulean,$cancut,[canflash],$cansurf,bike"
-						]
+                        "access_rules": ["$celadonnoflash,[canflash],bike,pokeflute","$fuchsianoflash,[canflash],bike"]
                     },
                     {
                         "name": "House Woman",
                         "item_count": 1,
-                        "access_rules": [
-							"$celadon,$cancut",
-							"$cerulean,$cancut,[canflash]"
-						]
+                        "access_rules": ["$celadonnoflash,[canflash],$cancut"]
                     }
                 ],
                 "map_locations": [
@@ -1176,9 +1156,8 @@
             {
                 "name": "Route 17",
                 "access_rules": [
-                    "$celadon,pokeflute,bike",
-                    "$fuchsia,bike",
-					"$cerulean,$cancut,[canflash],$cansurf,bike"
+                    "$celadonnoflash,[canflash],pokeflute,bike",
+                    "$fuchsianoflash,[canflash],bike"
                 ],
                 "sections": [
                     {
@@ -1228,8 +1207,7 @@
             {
                 "name": "Fuchsia City",
                 "access_rules": [
-                    "$fuchsia",
-					"$cerulean,$cancut,[canflash],$cansurf"
+                    "$fuchsianoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1266,10 +1244,7 @@
             },
             {
                 "name": "Safari Zone",
-                "access_rules": [
-					"$fuchsia,$safari",
-					"$cerulean,$cancut,[canflash],$cansurf,$safari"
-				],
+                "access_rules": ["$fuchsianoflash,[canflash],$safari"],
                 "sections": [
                     {
                         "name": "Center Zone Island Item",
@@ -1338,8 +1313,7 @@
             {
                 "name": "Route 15",
                 "access_rules": [
-                    "$fuchsia",
-					"$cerulean,$cancut,[canflash],$cansurf"
+                    "$fuchsianoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1374,10 +1348,7 @@
             },
             {
                 "name": "Route 14",
-                "access_rules": [
-					"$fuchsia",
-					"$cerulean,$cancut,[canflash],$cansurf"
-				],
+                "access_rules": ["$fuchsianoflash,[canflash]"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -1396,54 +1367,31 @@
             {
                 "name": "Route 13",
                 "access_rules": [
-                    "$fuchsia",
-					"$cerulean,$cancut,[canflash],$cansurf"
+                    "$fuchsianoflash,[canflash]"
                 ],
                 "sections": [
                     {
                         "name": "Dead End Bush Hidden",
                         "item_count": 1,
-                        "access_rules": [
-							"$fuchsia,itemfinder",
-							"$cerulean,$cancut,[canflash],$cansurf,itemfinder",
-							"$fuchsia,op_if_off",
-							"$cerulean,$cancut,[canflash],$cansurf,op_if_off"
-						],
+                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsianoflash,[canflash],op_if_off"],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Dead End By Water Corner Hidden",
                         "item_count": 1,
-                        "access_rules": [
-							"$fuchsia,itemfinder",
-							"$cerulean,$cancut,[canflash],$cansurf,itemfinder",
-							"$fuchsia,op_if_off",
-							"$cerulean,$cancut,[canflash],$cansurf,op_if_off"
-						],
+                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsianoflash,[canflash],op_if_off"],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Trainers",
                         "item_count": 7,
-                        "access_rules": [
-							"$fuchsia",
-							"$cerulean,$cancut,[canflash],$cansurf"
-						],
+                        "access_rules": ["$fuchsianoflash,[canflash]"],
                         "visibility_rules": ["op_trn_on"]
                     },
                     {
                         "name": "East Trainers",
                         "item_count": 3,
-                        "access_rules": [
-							"$fuchsia,$boulders",
-							"$cerulean,$cancut,[canflash],$boulders",
-							"$fuchsia,$cansurf",
-							"$cerulean,$cancut,[canflash],$cansurf",
-							"$lavender,$cansurf",
-							"$cerulean,$cancut,[canflash],$cansurf",
-							"$lavender,pokeflute",
-							"$cerulean,$cancut,[canflash],pokeflute"
-						],
+                        "access_rules": ["$fuchsianoflash,[canflash],$boulders","$fuchsianoflash,[canflash],$cansurf","$lavendernoflash,[canflash],$cansurf","$lavendernoflash,[canflash],pokeflute"],
                         "visibility_rules": ["op_trn_on"]
                     }
                 ],
@@ -1511,8 +1459,8 @@
             {
                 "name": "Rock Tunnel",
                 "access_rules": [
-                    "$cerulean,$cancut,[canflash]",
-                    "$lavender,[canflash]"
+                    "$cerulean,$cancut,$canflash",
+                    "$lavendernoflash,[canflash],$canflash"
                 ],
                 "sections": [
                     {
@@ -1713,10 +1661,7 @@
             },
             {
                 "name": "Rocket Hideout",
-                "access_rules": [
-					"$celadon,$hideout",
-					"$cerulean,$cancut,[canflash],$hideout"
-				],
+                "access_rules": ["$celadonnoflash,[canflash],$hideout"],
                 "sections": [
                     {
                         "name": "B1F West Item",
@@ -1789,10 +1734,7 @@
             },
             {
                 "name": "Rocket Hideout Trainers",
-                "access_rules": [
-					"$celadon,$hideout",
-					"$cerulean,$cancut,[canflash],$hideout"
-				],
+                "access_rules": ["$celadonnoflash,[canflash],$hideout"],
                 "sections": [
                     {
                         "name": "B1F Rockets",
@@ -1937,7 +1879,7 @@
                 "name": "Power Plant",
                 "access_rules": [
                     "$cerulean,$cancut,$cansurf",
-                    "$lavender,[canflash],$cansurf"
+                    "$lavendernoflash,[canflash],$canflash,$cansurf"
                 ],
                 "sections": [
                     {
@@ -2197,11 +2139,7 @@
             },
             {
                 "name": "Route 20 East",
-                "access_rules": [
-					"$cansurf,$canstrength",
-					"$fuchsia,$cansurf",
-					"$cerulean,$cancut,[canflash],$cansurf"
-				],
+                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2219,11 +2157,7 @@
             },
             {
                 "name": "Route 19",
-                "access_rules": [
-				    "$cansurf,$canstrength",
-					"$fuchsia,$cansurf",
-					"$cerulean,$cancut,[canflash],$cansurf"
-				],
+                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2241,10 +2175,7 @@
             },
             {
                 "name": "Route 18",
-                "access_rules": [
-				    "$fuchsia",
-					"$cerulean,$cancut,[canflash],$cansurf"
-				],
+                "access_rules": ["$fuchsianoflash,[canflash]"],
                 "sections": [
                     {
                         "name": "Trainers",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -501,7 +501,8 @@
                 "name": "Route 9",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -532,7 +533,8 @@
                 "name": "Route 10 North",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -560,6 +562,7 @@
                 "access_rules": [
                     "$cerulean,$cancut,[canflash]",
                     "$lavendernoflash,[canflash]"
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -586,6 +589,7 @@
                 "name": "Lavender Town",
                 "access_rules": [
                     "$lavendernoflash,[canflash]"
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -606,6 +610,7 @@
                 "name": "Route 8",
                 "access_rules": [
                     "$lavendernoflash,[canflash]"
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -625,7 +630,8 @@
             {
                 "name": "Pokemon Tower",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -946,7 +952,10 @@
                             "$vermillion,$boulders,$aide11",
                             "$lavendernoflash,[canflash],pokeflute,$aide11",
                             "$fuchsianoflash,[canflash],pokeflute,$boulders,$aide11",
-                            "$fuchsianoflash,[canflash],pokeflute,$cansurf,$aide11"
+                            "$fuchsianoflash,[canflash],pokeflute,$cansurf,$aide11",
+                            "$lavender,pokeflute,$aide11",
+                            "$fuchsia,pokeflute,$boulders,$aide11",
+                            "$fuchsia,pokeflute,$cansurf,$aide11"
                         ]
                     },
                     
@@ -958,10 +967,16 @@
                             "$lavendernoflash,[canflash],pokeflute,itemfinder",
                             "$fuchsianoflash,[canflash],pokeflute,$boulders,itemfinder",
                             "$fuchsianoflash,[canflash],pokeflute,surf,itemfinder",
+                            "$lavender,pokeflute,itemfinder",
+                            "$fuchsia,pokeflute,$boulders,itemfinder",
+                            "$fuchsia,pokeflute,surf,itemfinder",
                             "$vermillion,$boulders,op_if_off",
                             "$lavendernoflash,[canflash],pokeflute,op_if_off",
                             "$fuchsianoflash,[canflash],pokeflute,$boulders,op_if_off",
-                            "$fuchsianoflash,[canflash],pokeflute,surf,op_if_off"
+                            "$fuchsianoflash,[canflash],pokeflute,surf,op_if_off",
+                            "$lavender,pokeflute,op_if_off",
+                            "$fuchsia,pokeflute,$boulders,op_if_off",
+                            "$fuchsia,pokeflute,surf,op_if_off"
                         ],
                         "visibility_rules": ["op_hid_on"]
                     }
@@ -977,7 +992,8 @@
             {
                 "name": "Route 12 North",
                 "access_rules": [
-                    "$lavendernoflash,[canflash]"
+                    "$lavendernoflash,[canflash]",
+					"$lavender"
                 ],
                 "sections": [
                     {
@@ -1007,7 +1023,9 @@
                 "name": "Route 12 South",
                 "access_rules": [
                     "$lavendernoflash,[canflash],pokeflute",
-                    "$lavendernoflash,[canflash],$cansurf"
+                    "$lavendernoflash,[canflash],$cansurf",
+                    "$lavender,pokeflute",
+                    "$lavender,$cansurf"
                 ],
                 "sections": [
                     {
@@ -1041,7 +1059,7 @@
             },
             {
                 "name": "Underground Tunnel West-East",
-                "access_rules": ["$lavendernoflash,[canflash]"],
+                "access_rules": ["$lavendernoflash,[canflash]","$lavender"],
                 "sections": [
                     {
                         "name": "West Hidden",
@@ -1072,7 +1090,8 @@
             {
                 "name": "Celadon City",
                 "access_rules": [
-                    "$celadonnoflash,[canflash]"
+                    "$celadonnoflash,[canflash]",
+					"$celadon"
                 ],
                 "sections": [
                     {
@@ -1137,12 +1156,12 @@
                         "name": "Trainers",
                         "item_count": 6,
                         "visibility_rules": ["op_trn_on"],
-                        "access_rules": ["$celadonnoflash,[canflash],bike,pokeflute","$fuchsianoflash,[canflash],bike"]
+                        "access_rules": ["$celadonnoflash,[canflash],bike,pokeflute","$celadon,bike,pokeflute","$fuchsianoflash,[canflash],bike","$fuchsia,bike"]
                     },
                     {
                         "name": "House Woman",
                         "item_count": 1,
-                        "access_rules": ["$celadonnoflash,[canflash],$cancut"]
+                        "access_rules": ["$celadonnoflash,[canflash],$cancut","$celadon,$cancut"]
                     }
                 ],
                 "map_locations": [
@@ -1157,7 +1176,9 @@
                 "name": "Route 17",
                 "access_rules": [
                     "$celadonnoflash,[canflash],pokeflute,bike",
-                    "$fuchsianoflash,[canflash],bike"
+                    "$fuchsianoflash,[canflash],bike",
+                    "$celadon,pokeflute,bike",
+                    "$fuchsia,bike"
                 ],
                 "sections": [
                     {
@@ -1207,7 +1228,8 @@
             {
                 "name": "Fuchsia City",
                 "access_rules": [
-                    "$fuchsianoflash,[canflash]"
+                    "$fuchsianoflash,[canflash]",
+					"$fuchsia"
                 ],
                 "sections": [
                     {
@@ -1244,7 +1266,7 @@
             },
             {
                 "name": "Safari Zone",
-                "access_rules": ["$fuchsianoflash,[canflash],$safari"],
+                "access_rules": ["$fuchsianoflash,[canflash],$safari","$fuchsia,$safari"],
                 "sections": [
                     {
                         "name": "Center Zone Island Item",
@@ -1313,7 +1335,8 @@
             {
                 "name": "Route 15",
                 "access_rules": [
-                    "$fuchsianoflash,[canflash]"
+                    "$fuchsianoflash,[canflash]",
+					"$fuchsia"
                 ],
                 "sections": [
                     {
@@ -1348,7 +1371,7 @@
             },
             {
                 "name": "Route 14",
-                "access_rules": ["$fuchsianoflash,[canflash]"],
+                "access_rules": ["$fuchsianoflash,[canflash]","$fuchsia"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -1367,31 +1390,34 @@
             {
                 "name": "Route 13",
                 "access_rules": [
-                    "$fuchsianoflash,[canflash]"
+                    "$fuchsianoflash,[canflash]",
+					"$fuchsia"
                 ],
                 "sections": [
                     {
                         "name": "Dead End Bush Hidden",
                         "item_count": 1,
-                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsianoflash,[canflash],op_if_off"],
+                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsia,itemfinder","$fuchsianoflash,[canflash],op_if_off","$fuchsia,op_if_off"],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Dead End By Water Corner Hidden",
                         "item_count": 1,
-                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsianoflash,[canflash],op_if_off"],
+                        "access_rules": ["$fuchsianoflash,[canflash],itemfinder","$fuchsia,itemfinder","$fuchsianoflash,[canflash],op_if_off","$fuchsia,op_if_off"],
                         "visibility_rules": ["op_hid_on"]
                     },
                     {
                         "name": "Trainers",
                         "item_count": 7,
-                        "access_rules": ["$fuchsianoflash,[canflash]"],
+                        "access_rules": ["$fuchsianoflash,[canflash]","$fichsia"],
                         "visibility_rules": ["op_trn_on"]
                     },
                     {
                         "name": "East Trainers",
                         "item_count": 3,
-                        "access_rules": ["$fuchsianoflash,[canflash],$boulders","$fuchsianoflash,[canflash],$cansurf","$lavendernoflash,[canflash],$cansurf","$lavendernoflash,[canflash],pokeflute"],
+                        "access_rules": ["$fuchsianoflash,[canflash],$boulders","$fuchsianoflash,[canflash],$cansurf","$lavendernoflash,[canflash],$cansurf","$lavendernoflash,[canflash],pokeflute",
+						"$fuchsia,$boulders","$fuchsia,$cansurf","$lavender,$cansurf","$lavender,pokeflute"
+						],
                         "visibility_rules": ["op_trn_on"]
                     }
                 ],
@@ -1460,7 +1486,7 @@
                 "name": "Rock Tunnel",
                 "access_rules": [
                     "$cerulean,$cancut,[canflash]",
-                    "$lavendernoflash,[canflash],[canflash]"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -1661,7 +1687,7 @@
             },
             {
                 "name": "Rocket Hideout",
-                "access_rules": ["$celadonnoflash,[canflash],$hideout"],
+                "access_rules": ["$celadonnoflash,[canflash],$hideout","$celadon,$hideout"],
                 "sections": [
                     {
                         "name": "B1F West Item",
@@ -1734,7 +1760,7 @@
             },
             {
                 "name": "Rocket Hideout Trainers",
-                "access_rules": ["$celadonnoflash,[canflash],$hideout"],
+                "access_rules": ["$celadonnoflash,[canflash],$hideout","$celadon,$hideout"],
                 "sections": [
                     {
                         "name": "B1F Rockets",
@@ -1879,7 +1905,7 @@
                 "name": "Power Plant",
                 "access_rules": [
                     "$cerulean,$cancut,$cansurf",
-                    "$lavendernoflash,[canflash],[canflash],$cansurf"
+                    "$lavendernoflash,[canflash],$cansurf"
                 ],
                 "sections": [
                     {
@@ -2139,7 +2165,7 @@
             },
             {
                 "name": "Route 20 East",
-                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf"],
+                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf","$fuchsia,$cansurf"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2157,7 +2183,7 @@
             },
             {
                 "name": "Route 19",
-                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf"],
+                "access_rules": ["$cansurf,$canstrength","$fuchsianoflash,[canflash],$cansurf","$fuchsia,$cansurf"],
                 "sections": [
                     {
                         "name": "Trainers",
@@ -2175,7 +2201,7 @@
             },
             {
                 "name": "Route 18",
-                "access_rules": ["$fuchsianoflash,[canflash]"],
+                "access_rules": ["$fuchsianoflash,[canflash]","$fuchsia"],
                 "sections": [
                     {
                         "name": "Trainers",

--- a/locations/locations.json
+++ b/locations/locations.json
@@ -501,7 +501,7 @@
                 "name": "Route 9",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavendernoflash,[canflash],$canflash"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -532,7 +532,7 @@
                 "name": "Route 10 North",
                 "access_rules": [
                     "$cerulean,$cancut",
-                    "$lavendernoflash,[canflash],$canflash"
+                    "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
                     {
@@ -558,7 +558,7 @@
             {
                 "name": "Route 10 South",
                 "access_rules": [
-                    "$cerulean,$cancut,$canflash",
+                    "$cerulean,$cancut,[canflash]",
                     "$lavendernoflash,[canflash]"
                 ],
                 "sections": [
@@ -1459,8 +1459,8 @@
             {
                 "name": "Rock Tunnel",
                 "access_rules": [
-                    "$cerulean,$cancut,$canflash",
-                    "$lavendernoflash,[canflash],$canflash"
+                    "$cerulean,$cancut,[canflash]",
+                    "$lavendernoflash,[canflash],[canflash]"
                 ],
                 "sections": [
                     {
@@ -1879,7 +1879,7 @@
                 "name": "Power Plant",
                 "access_rules": [
                     "$cerulean,$cancut,$cansurf",
-                    "$lavendernoflash,[canflash],$canflash,$cansurf"
+                    "$lavendernoflash,[canflash],[canflash],$cansurf"
                 ],
                 "sections": [
                     {

--- a/scripts/logic.lua
+++ b/scripts/logic.lua
@@ -375,8 +375,22 @@ function lavender()
     )
 end
 
+function lavendernoflash()
+    return (
+      flylavender() or flyceladon()
+      or ((flypewter() or flycerulean() or flyvermillion() or oldman()) and (cancut() or guard() or (boulders() and pokeflute())))
+      or (flyfuchsia() and ((pokeflute() and (boulders() or bike())) or cansurf()))
+      or (canstrength() and cansurf())
+      or (flysaffron() and guard())
+    )
+end
+
 function celadon()
     return lavender()
+end
+
+function celadonnoflash()
+    return lavendernoflash()
 end
 
 function saffron()
@@ -393,6 +407,18 @@ function fuchsia()
         or (cansurf() and canstrength())
         or ((flypewter() or flycerulean() or flyvermillion() or oldman())
             and (((cancut() and canflash()) or guard() or (boulders() and pokeflute())) and (((pokeflute() and (boulders() or bike())) or cansurf()))))
+        or ((flyceladon() or flylavender()) and ((pokeflute() and (boulders() or bike())) or cansurf()))
+        or (canstrength() and cansurf())
+        or (flysaffron() and (guard() and ((pokeflute() and (boulders() or bike())) or cansurf())))
+    )
+end
+
+function fuchsianoflash()
+    return (
+        flyfuchsia()
+        or (cansurf() and canstrength())
+        or ((flypewter() or flycerulean() or flyvermillion() or oldman())
+            and ((cancut() or guard() or (boulders() and pokeflute())) and (((pokeflute() and (boulders() or bike())) or cansurf()))))
         or ((flyceladon() or flylavender()) and ((pokeflute() and (boulders() or bike())) or cansurf()))
         or (canstrength() and cansurf())
         or (flysaffron() and (guard() and ((pokeflute() and (boulders() or bike())) or cansurf())))


### PR DESCRIPTION
Added all possible cases where you can access a location or check when you are only lacking flash. This now has them all show up as OOL unless you have flash. For some, this was a simple as changing `$canflash` to `[canflash]`, for others it required adding a possible access requirement needing access to Cerulean and being able to cut. For example, for Lavender Town:
```
"access_rules": [
    "$lavender",
    "$cerulean,$cancut,[canflash]"
]
```
For Fuchsia City:
```
"access_rules": [
    "$fuchsia",
    "$cerulean,$cancut,[canflash],$cansurf"
]
```

This had to be done for all possible ways to a check, since changing logic.lua in the scrips folder would make it think you can do it in logic when you can't, and this therefore was the cleanest way I could think of to add this in.